### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ La información del curso se proporcionará mediante presentaciones o mediante r
         <td>7</td>
         <td>18/03/2024</td>
         <td>Módulos y paquetes</td>
-        <td><a href="https://github.com/fegonzalez7/poo_unal_clase10">Clase 11</a></td>
+        <td><a href="https://github.com/fegonzalez7/poo_unal_clase11">Clase 11</a></td>
       </tr>
       <tr>
         <td>Semana</td>


### PR DESCRIPTION
In the  last version of the repo, the link of the 11 class redirect us to the 10 class repo
I solve this